### PR TITLE
enable cross-account access

### DIFF
--- a/terraform/cross_account/README.md
+++ b/terraform/cross_account/README.md
@@ -2,7 +2,9 @@
 
 _Based on [these steps](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)._
 
-To add a new destination account:
+**Source account: `133032889584`**
+
+## Adding a new destination account
 
 1. [Log in](https://console.aws.amazon.com/console/home) to the destination account.
 1. [Create a role for "another AWS account"](https://console.aws.amazon.com/iam/home#/roles$new?step=type&roleType=crossAccount). For the `Account ID`, enter `133032889584`.
@@ -11,6 +13,11 @@ To add a new destination account:
 1. Set a `Role name` of `CrossAccountAdmin`.
 1. Create it.
 1. Add to the [`dest_account_numbers`](vars.tf).
-1. Using credentials for the AWS account `133032889584`, run a `terraform apply` from this directory.
+1. Using credentials for the source account, run a `terraform apply` from this directory.
 
-[More about switching roles.](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/id_roles_use_switch-role-console.html)
+## Signing in
+
+1. [Log in to the source account.](https://133032889584.signin.aws.amazon.com/console)
+1. Use the output `switch_role_urls` from Terraform.
+
+[More info.](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/id_roles_use_switch-role-console.html)

--- a/terraform/cross_account/README.md
+++ b/terraform/cross_account/README.md
@@ -1,0 +1,12 @@
+# AWS cross-account access
+
+To add a new destination account:
+
+1. [Log in](https://console.aws.amazon.com/console/home) to the destination account.
+1. [Create a role for "another AWS account"](https://console.aws.amazon.com/iam/home#/roles$new?step=type&roleType=crossAccount). For the `Account ID`, enter `133032889584`.
+1. Select the [`AdministratorAccess`](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_administrator) policy.
+1. Add a tag of `Project`: `https://github.com/18F/aws-admin`.
+1. Add to the [`dest_account_numbers`](vars.tf).
+1. Run a `terraform apply` from this directory.
+
+_Based on [these steps](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html#tutorial_cross-account-with-roles-1)._

--- a/terraform/cross_account/README.md
+++ b/terraform/cross_account/README.md
@@ -1,12 +1,16 @@
 # AWS cross-account access
 
+_Based on [these steps](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html)._
+
 To add a new destination account:
 
 1. [Log in](https://console.aws.amazon.com/console/home) to the destination account.
 1. [Create a role for "another AWS account"](https://console.aws.amazon.com/iam/home#/roles$new?step=type&roleType=crossAccount). For the `Account ID`, enter `133032889584`.
 1. Select the [`AdministratorAccess`](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_administrator) policy.
 1. Add a tag of `Project`: `https://github.com/18F/aws-admin`.
+1. Set a `Role name` of `CrossAccountAdmin`.
+1. Create it.
 1. Add to the [`dest_account_numbers`](vars.tf).
-1. Run a `terraform apply` from this directory.
+1. Using credentials for the AWS account `133032889584`, run a `terraform apply` from this directory.
 
-_Based on [these steps](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html#tutorial_cross-account-with-roles-1)._
+[More about switching roles.](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/id_roles_use_switch-role-console.html)

--- a/terraform/cross_account/main.tf
+++ b/terraform/cross_account/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "~> 2.32"
-  region = "us-east-1"
+  region  = "us-east-1"
 }
 
 resource "aws_iam_group" "admins" {
@@ -22,8 +22,4 @@ resource "aws_iam_policy" "assume_role" {
 resource "aws_iam_group_policy_attachment" "assume_role" {
   group      = "${aws_iam_group.admins.name}"
   policy_arn = "${aws_iam_policy.assume_role.arn}"
-}
-
-output "switch_role_urls" {
-  value = { for acct in var.dest_account_numbers : "${acct}" => "https://signin.aws.amazon.com/switchrole?roleName=${var.role_name}&account=${acct}&displayName=${acct}" }
 }

--- a/terraform/cross_account/main.tf
+++ b/terraform/cross_account/main.tf
@@ -11,12 +11,12 @@ resource "aws_iam_group" "admins" {
 data "aws_iam_policy_document" "cross_account" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["arn:aws:iam::${var.dest_account_number}:role/${var.role_name}"]
+    resources = [for acct in var.dest_account_numbers : "arn:aws:iam::${acct}:role/${var.role_name}"]
   }
 }
 
 resource "aws_iam_policy" "assume_role" {
-  name = "allow-assume-cross-account-role"
+  name   = "allow-assume-cross-account-role"
   policy = "${data.aws_iam_policy_document.cross_account.json}"
 }
 
@@ -25,6 +25,6 @@ resource "aws_iam_group_policy_attachment" "assume_role" {
   policy_arn = "${aws_iam_policy.assume_role.arn}"
 }
 
-output "switch_role_url" {
-  value = "https://signin.aws.amazon.com/switchrole?roleName=${var.role_name}&account=${var.dest_account_number}&displayName=${var.dest_account_number}"
+output "switch_role_urls" {
+  value = { for acct in var.dest_account_numbers : "${acct}" => "https://signin.aws.amazon.com/switchrole?roleName=${var.role_name}&account=${acct}&displayName=${acct}" }
 }

--- a/terraform/cross_account/main.tf
+++ b/terraform/cross_account/main.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  version = "~> 2.32"
+  # account: tts-prod (133032889584)
+  region  = "us-east-1"
+}
+
+resource "aws_iam_group" "admins" {
+  name = "tts-tech-portfolio-admins"
+}
+
+resource "aws_iam_policy" "assume_role" {
+  name        = "allow-assume-cross-account-role"
+  # description = "A test policy"
+  policy      = <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Resource": "arn:aws:iam::144433228153:role/CrossAccountAdmin"
+  }
+}
+JSON
+}
+
+resource "aws_iam_group_policy_attachment" "assume_role" {
+  group      = "${aws_iam_group.admins.name}"
+  policy_arn = "${aws_iam_policy.assume_role.arn}"
+}

--- a/terraform/cross_account/main.tf
+++ b/terraform/cross_account/main.tf
@@ -1,26 +1,23 @@
 provider "aws" {
   version = "~> 2.32"
   # account: tts-prod (133032889584)
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 resource "aws_iam_group" "admins" {
   name = "tts-tech-portfolio-admins"
 }
 
-resource "aws_iam_policy" "assume_role" {
-  name        = "allow-assume-cross-account-role"
-  # description = "A test policy"
-  policy      = <<JSON
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "sts:AssumeRole",
-    "Resource": "arn:aws:iam::144433228153:role/CrossAccountAdmin"
+data "aws_iam_policy_document" "cross_account" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::144433228153:role/CrossAccountAdmin"]
   }
 }
-JSON
+
+resource "aws_iam_policy" "assume_role" {
+  name = "allow-assume-cross-account-role"
+  policy = "${data.aws_iam_policy_document.cross_account.json}"
 }
 
 resource "aws_iam_group_policy_attachment" "assume_role" {

--- a/terraform/cross_account/main.tf
+++ b/terraform/cross_account/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   version = "~> 2.32"
-  # account: tts-prod (133032889584)
   region = "us-east-1"
 }
 

--- a/terraform/cross_account/main.tf
+++ b/terraform/cross_account/main.tf
@@ -11,7 +11,7 @@ resource "aws_iam_group" "admins" {
 data "aws_iam_policy_document" "cross_account" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["arn:aws:iam::144433228153:role/CrossAccountAdmin"]
+    resources = ["arn:aws:iam::${var.dest_account_number}:role/${var.role_name}"]
   }
 }
 
@@ -23,4 +23,8 @@ resource "aws_iam_policy" "assume_role" {
 resource "aws_iam_group_policy_attachment" "assume_role" {
   group      = "${aws_iam_group.admins.name}"
   policy_arn = "${aws_iam_policy.assume_role.arn}"
+}
+
+output "switch_role_url" {
+  value = "https://signin.aws.amazon.com/switchrole?roleName=${var.role_name}&account=${var.dest_account_number}&displayName=${var.dest_account_number}"
 }

--- a/terraform/cross_account/outputs.tf
+++ b/terraform/cross_account/outputs.tf
@@ -1,0 +1,3 @@
+output "switch_role_urls" {
+  value = { for acct in var.dest_account_numbers : "${acct}" => "https://signin.aws.amazon.com/switchrole?roleName=${var.role_name}&account=${acct}&displayName=${acct}" }
+}

--- a/terraform/cross_account/vars.tf
+++ b/terraform/cross_account/vars.tf
@@ -1,0 +1,9 @@
+variable "dest_account_number" {
+  description = "The account number you want to be able to switch into."
+  default = "144433228153"
+}
+
+variable "role_name" {
+  default = "CrossAccountAdmin"
+}
+

--- a/terraform/cross_account/vars.tf
+++ b/terraform/cross_account/vars.tf
@@ -1,6 +1,30 @@
 variable "dest_account_numbers" {
   description = "The account numbers you want to be able to switch into."
-  default     = ["001907687576", "144433228153"]
+  # should include everything in
+  # https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0
+  default = [
+    "001907687576",
+    "034795980528",
+    "096224847349",
+    "133032889584",
+    "144433228153",
+    "195022191070",
+    "213305845712",
+    "312530187933",
+    "340731855345",
+    "405436375165",
+    "461353137281",
+    "469931042344",
+    "541873662368",
+    "555546682965",
+    "560284223511",
+    "570696747145",
+    "587807691409",
+    "699351240001",
+    "765358534566",
+    "894947205914",
+    "992476103436",
+  ]
 }
 
 variable "role_name" {

--- a/terraform/cross_account/vars.tf
+++ b/terraform/cross_account/vars.tf
@@ -1,6 +1,6 @@
 variable "dest_account_numbers" {
   description = "The account numbers you want to be able to switch into."
-  default     = ["144433228153"]
+  default     = ["001907687576", "144433228153"]
 }
 
 variable "role_name" {

--- a/terraform/cross_account/vars.tf
+++ b/terraform/cross_account/vars.tf
@@ -1,6 +1,6 @@
-variable "dest_account_number" {
-  description = "The account number you want to be able to switch into."
-  default = "144433228153"
+variable "dest_account_numbers" {
+  description = "The account numbers you want to be able to switch into."
+  default     = ["144433228153"]
 }
 
 variable "role_name" {

--- a/terraform/cross_account/versions.tf
+++ b/terraform/cross_account/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Closes https://github.com/18F/tts-tech-portfolio/issues/65.

This pull request provides code and instructions for allowing cross-account access via IAM. Notes:

- It's a standalone module, not integrated with the others. I'm still trying to figure out the best way to do so, if at all.
- While I listed all the destination account numbers on the source account side, I haven't actually gone through and enabled the incoming access for all of the destination accounts. In other words, not all of them will work yet. Tracking in [the account list](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0).