### PR TITLE
send budget alerts for all business units

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,21 @@ _Based on [these steps](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/t
 1. Use the `Switch role URL` from the [AWS accounts list](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=0)
 
 [More info.](https://docs.aws.amazon.com/en_pv/IAM/latest/UserGuide/id_roles_use_switch-role-console.html)
+
+## Budgets
+
+Budgets are listed by business unit in two places:
+
+- [The AWS accounts spreadsheet](https://docs.google.com/spreadsheets/d/1DedSCiU9AsCAAVvAFZT0_Ii7AFIKlI-JNifzlpHNbDg/edit#gid=1269506691)
+- AWS Systems Manager Parameter Store
+
+To add a new one:
+
+1. Sign into the payer account
+1. Go to the [Parameter Store](https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table#list_parameter_filters=Name:BeginsWith:%2Ftts%2Faws-budget)
+1. Create a parameter
+   1. For `Name`, use `/tts/aws-budget/<BUSINESS UNIT>`
+   1. For `Value`, enter the monthly budget
+1. Mimic [use of the `business_unit` module](terraform/organization.tf)
+
+_Parameter Store is used to keep the values private._

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To add a new one:
 1. Go to the [Parameter Store](https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table#list_parameter_filters=Name:BeginsWith:%2Ftts%2Faws-budget)
 1. Create a parameter
    1. For `Name`, use `/tts/aws-budget/<BUSINESS UNIT>`
-   1. For `Value`, enter the monthly budget
+   1. For `Value`, enter the monthly budget as an integer
 1. Mimic [use of the `business_unit` module](terraform/organization.tf)
 
 _Parameter Store is used to keep the values private._

--- a/terraform/business_unit/main.tf
+++ b/terraform/business_unit/main.tf
@@ -5,6 +5,10 @@ resource "aws_organizations_organizational_unit" "bu" {
   parent_id = data.aws_organizations_organization.main.roots.0.id
 }
 
+data "aws_ssm_parameter" "monthly_limit" {
+  name = "/tts/aws-budget/${var.budget_param_name}"
+}
+
 locals {
   tech_portfolio_email = "devops@gsa.gov"
 }
@@ -15,7 +19,7 @@ resource "aws_budgets_budget" "bu" {
   budget_type = "COST"
   limit_unit  = "USD"
   # for some reason it adds a single decimal
-  limit_amount      = "${var.monthly_limit}.0"
+  limit_amount      = "${data.aws_ssm_parameter.monthly_limit.value}.0"
   time_period_start = "2019-11-07_00:00"
   time_unit         = "MONTHLY"
 

--- a/terraform/business_unit/vars.tf
+++ b/terraform/business_unit/vars.tf
@@ -2,11 +2,11 @@ variable "name" {
   type = string
 }
 
-variable "email" {
-  type = string
+variable "budget_param_name" {
+  type        = string
+  description = "Name of the AWS Systems Manager Parameter Store budget, excluding the path"
 }
 
-variable "monthly_limit" {
-  type        = number
-  description = "The budget amount, in dollars"
+variable "email" {
+  type = string
 }

--- a/terraform/organization.tf
+++ b/terraform/organization.tf
@@ -47,7 +47,7 @@ module "tech_portfolio" {
     aws = aws.payer
   }
 
-  name          = "Tech Portfolio"
-  email         = "devops@gsa.gov"
-  monthly_limit = 2000
+  name              = "Tech Portfolio"
+  budget_param_name = "tech-portfolio"
+  email             = "devops@gsa.gov"
 }

--- a/terraform/organization.tf
+++ b/terraform/organization.tf
@@ -11,34 +11,59 @@ data "aws_organizations_organization" "main" {
   provider = aws.payer
 }
 
-resource "aws_organizations_organizational_unit" "u_18f" {
-  provider  = aws.payer
-  name      = "18F"
-  parent_id = data.aws_organizations_organization.main.roots.0.id
+module "u_18f" {
+  source = "./business_unit"
+  providers = {
+    aws = aws.payer
+  }
+
+  name              = "18F"
+  budget_param_name = "18f"
+  email             = "devops@gsa.gov"
 }
 
-resource "aws_organizations_organizational_unit" "cloud_gov" {
-  provider  = aws.payer
-  name      = "cloud.gov"
-  parent_id = data.aws_organizations_organization.main.roots.0.id
+module "cloud_gov" {
+  source = "./business_unit"
+  providers = {
+    aws = aws.payer
+  }
+
+  name              = "cloud.gov"
+  budget_param_name = "cloud.gov"
+  email             = "support@cloud.gov"
 }
 
-resource "aws_organizations_organizational_unit" "coe" {
-  provider  = aws.payer
-  name      = "COE"
-  parent_id = data.aws_organizations_organization.main.roots.0.id
+module "coe" {
+  source = "./business_unit"
+  providers = {
+    aws = aws.payer
+  }
+
+  name              = "Centers of Excellence"
+  budget_param_name = "coe"
+  email             = "connectcoe@gsa.gov"
 }
 
-resource "aws_organizations_organizational_unit" "login_gov" {
-  provider  = aws.payer
-  name      = "login.gov"
-  parent_id = data.aws_organizations_organization.main.roots.0.id
+module "login_gov" {
+  source = "./business_unit"
+  providers = {
+    aws = aws.payer
+  }
+
+  name              = "login.gov"
+  budget_param_name = "login.gov"
+  email             = "security-team@login.gov"
 }
 
-resource "aws_organizations_organizational_unit" "opp" {
-  provider  = aws.payer
-  name      = "OPP"
-  parent_id = data.aws_organizations_organization.main.roots.0.id
+module "solutions" {
+  source = "./business_unit"
+  providers = {
+    aws = aws.payer
+  }
+
+  name              = "Solutions"
+  budget_param_name = "solutions"
+  email             = "devops@gsa.gov"
 }
 
 module "tech_portfolio" {


### PR DESCRIPTION
Closes https://github.com/18F/aws-admin/issues/19. Builds on #50. Picked this up in service of https://github.com/18F/tts-tech-portfolio-private/issues/954.

Most of the alerts just go to devops@gsa.gov for now, which we can change later.