### PR TITLE
leverage cost category for budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ To add a new one:
 1. Go to the [Parameter Store](https://console.aws.amazon.com/systems-manager/parameters/?region=us-east-1&tab=Table#list_parameter_filters=Name:BeginsWith:%2Ftts%2Faws-budget)
 1. Create a parameter
    1. For `Name`, use `/tts/aws-budget/<BUSINESS UNIT>`
+      - Make `<BUSINESS UNIT>` lower-case, alphanumeric, with hyphens
    1. For `Value`, enter the monthly budget as an integer
 1. Mimic [use of the `business_unit` module](terraform/organization.tf)
 

--- a/terraform/business_unit/main.tf
+++ b/terraform/business_unit/main.tf
@@ -6,7 +6,7 @@ resource "aws_organizations_organizational_unit" "bu" {
 }
 
 data "aws_ssm_parameter" "monthly_limit" {
-  name = "/tts/aws-budget/${var.budget_param_name}"
+  name = "/tts/aws-budget/${var.name}"
 }
 
 locals {
@@ -24,7 +24,7 @@ resource "aws_budgets_budget" "bu" {
   time_unit         = "MONTHLY"
 
   cost_filters = {
-    CostCategory = join("$", ["Business Units", coalesce(var.cost_category_name, var.name)])
+    CostCategory = join("$", ["Business Units", var.name])
   }
 
   notification {

--- a/terraform/business_unit/main.tf
+++ b/terraform/business_unit/main.tf
@@ -24,8 +24,7 @@ resource "aws_budgets_budget" "bu" {
   time_unit         = "MONTHLY"
 
   cost_filters = {
-    # https://github.com/terraform-providers/terraform-provider-aws/issues/5890#issuecomment-485600055
-    LinkedAccount = join(",", [for acct in aws_organizations_organizational_unit.bu.accounts : acct.id])
+    CostCategory = join("$", ["Business Units", coalesce(var.cost_category_name, var.name)])
   }
 
   notification {

--- a/terraform/business_unit/vars.tf
+++ b/terraform/business_unit/vars.tf
@@ -2,17 +2,6 @@ variable "name" {
   type = string
 }
 
-variable "budget_param_name" {
-  type        = string
-  description = "Name of the AWS Systems Manager Parameter Store budget, excluding the path"
-}
-
-variable "cost_category_name" {
-  type        = string
-  default     = null
-  description = "The rule within the Business Units cost category. Defaults to the name."
-}
-
 variable "email" {
   type = string
 }

--- a/terraform/business_unit/vars.tf
+++ b/terraform/business_unit/vars.tf
@@ -7,6 +7,12 @@ variable "budget_param_name" {
   description = "Name of the AWS Systems Manager Parameter Store budget, excluding the path"
 }
 
+variable "cost_category_name" {
+  type        = string
+  default     = null
+  description = "The rule within the Business Units cost category. Defaults to the name."
+}
+
 variable "email" {
   type = string
 }

--- a/terraform/organization.tf
+++ b/terraform/organization.tf
@@ -17,9 +17,8 @@ module "u_18f" {
     aws = aws.payer
   }
 
-  name              = "18F"
-  budget_param_name = "18f"
-  email             = "devops@gsa.gov"
+  name  = "18f"
+  email = "devops@gsa.gov"
 }
 
 module "cloud_gov" {
@@ -28,10 +27,8 @@ module "cloud_gov" {
     aws = aws.payer
   }
 
-  name               = "cloud.gov"
-  budget_param_name  = "cloud.gov"
-  cost_category_name = "cloud-gov"
-  email              = "support@cloud.gov"
+  name  = "cloud-gov"
+  email = "support@cloud.gov"
 }
 
 module "coe" {
@@ -40,9 +37,8 @@ module "coe" {
     aws = aws.payer
   }
 
-  name              = "Centers of Excellence"
-  budget_param_name = "coe"
-  email             = "connectcoe@gsa.gov"
+  name  = "coe"
+  email = "connectcoe@gsa.gov"
 }
 
 module "login_gov" {
@@ -51,10 +47,8 @@ module "login_gov" {
     aws = aws.payer
   }
 
-  name               = "login.gov"
-  budget_param_name  = "login.gov"
-  cost_category_name = "login-gov"
-  email              = "security-team@login.gov"
+  name  = "login-gov"
+  email = "security-team@login.gov"
 }
 
 module "solutions" {
@@ -63,9 +57,8 @@ module "solutions" {
     aws = aws.payer
   }
 
-  name              = "Solutions"
-  budget_param_name = "solutions"
-  email             = "devops@gsa.gov"
+  name  = "solutions"
+  email = "devops@gsa.gov"
 }
 
 module "tech_portfolio" {
@@ -74,7 +67,6 @@ module "tech_portfolio" {
     aws = aws.payer
   }
 
-  name              = "Tech Portfolio"
-  budget_param_name = "tech-portfolio"
-  email             = "devops@gsa.gov"
+  name  = "tech-portfolio"
+  email = "devops@gsa.gov"
 }

--- a/terraform/organization.tf
+++ b/terraform/organization.tf
@@ -28,9 +28,10 @@ module "cloud_gov" {
     aws = aws.payer
   }
 
-  name              = "cloud.gov"
-  budget_param_name = "cloud.gov"
-  email             = "support@cloud.gov"
+  name               = "cloud.gov"
+  budget_param_name  = "cloud.gov"
+  cost_category_name = "cloud-gov"
+  email              = "support@cloud.gov"
 }
 
 module "coe" {
@@ -50,9 +51,10 @@ module "login_gov" {
     aws = aws.payer
   }
 
-  name              = "login.gov"
-  budget_param_name = "login.gov"
-  email             = "security-team@login.gov"
+  name               = "login.gov"
+  budget_param_name  = "login.gov"
+  cost_category_name = "login-gov"
+  email              = "security-team@login.gov"
 }
 
 module "solutions" {


### PR DESCRIPTION
Closes #38. In service of https://github.com/18F/tts-tech-portfolio-private/issues/954.

Cost Categories are basically just a different way of grouping accounts (among other things), but are a) more flexible and b) can be used in more places than Organizational Units. Its existence means we're able to see the breakdown by business unit in the Cost Explorer:

<img width="926" alt="Screen Shot 2020-06-17 at 8 01 03 PM" src="https://user-images.githubusercontent.com/86842/84962693-71ae6a80-b0d5-11ea-89af-42c0e6f54aaa.png">

This also means that Terraform doesn't need to be re-run if any new accounts are added for them to show up in the Budgets.