### PR TITLE
remove redundant version specification

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,3 +1,0 @@
-terraform {
-  required_version = ">= 0.12"
-}


### PR DESCRIPTION
Minor cleanup: `required_version` was being specified in `versions.tf` and `main.tf`.