### PR TITLE
add script for GovCloud account setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_account.md
+++ b/.github/ISSUE_TEMPLATE/new_account.md
@@ -27,6 +27,7 @@ assignees: ""
 1. [ ] Set up GovCloud (if applicable)
    1. [ ] Send a request with the account number to govcloud-onboarding@amazon.com and CC cloudteam@4points.com, devops@gsa.gov, and brian.burns@gsa.gov
    1. [ ] Follow instructions from AWS to get credentials
+   1. [ ] Add (provided) GovCloud root account access key and secret to [KeePass](https://drive.google.com/drive/folders/1iQnvC8o_MU_DR5u7TYtC9pEKZXtBq03f?usp=sharing) and re-upload database
    1. [ ] Run the [GovCloud account setup script](https://github.com/18F/aws-admin/blob/master/bin/set_up_govcloud.sh)
    1. [ ] Create user for requester
 1. [ ] Set up cross-account access

--- a/.github/ISSUE_TEMPLATE/new_account.md
+++ b/.github/ISSUE_TEMPLATE/new_account.md
@@ -26,7 +26,8 @@ assignees: ""
 1. [ ] Set the [program team mailing list](https://docs.google.com/spreadsheets/d/12pfcEIEXaJTjIKex-3wnI89erIvgKf9B_XpGkDl6qsM/edit#gid=1235102795) as the [Operations Contact](https://console.aws.amazon.com/billing/home?#/account)
 1. [ ] Set up GovCloud (if applicable)
    1. [ ] Send a request with the account number to govcloud-onboarding@amazon.com and CC cloudteam@4points.com, devops@gsa.gov, and brian.burns@gsa.gov
-   1. [ ] Get credentials from AWS
+   1. [ ] Follow instructions from AWS to get credentials
+   1. [ ] Run the [GovCloud account setup script](https://github.com/18F/aws-admin/blob/master/bin/set_up_govcloud.sh)
    1. [ ] Create user for requester
 1. [ ] Set up cross-account access
    1. [ ] [Create a role for "another AWS account"](https://console.aws.amazon.com/iam/home#/roles$new?step=type&roleType=crossAccount). For the `Account ID`, enter `133032889584`.

--- a/bin/set_up_govcloud.sh
+++ b/bin/set_up_govcloud.sh
@@ -4,8 +4,8 @@ set -e
 set -x
 
 # required environment variables:
-# AWS_ACCESS_KEY_ID
-# AWS_SECRET_ACCESS_KEY
+# AWS_ACCESS_KEY_ID - for the GovCloud account
+# AWS_SECRET_ACCESS_KEY - (ditto)
 # USERNAME (optional - set on system by default)
 
 # based on

--- a/bin/set_up_govcloud.sh
+++ b/bin/set_up_govcloud.sh
@@ -23,8 +23,20 @@ aws iam attach-group-policy --group-name "$GROUP_NAME" --policy-arn arn:aws:iam:
 aws iam create-user --user-name "$USERNAME"
 aws iam add-user-to-group --group-name "$GROUP_NAME" --user-name "$USERNAME"
 
+# turn off echoing
+set +x
+
+# Read Password
+echo -n "Password for new IAM user: "
+read -s PASSWORD
+echo
+
 # Command to add a password to the user:
-aws iam create-login-profile -u "$USERNAME" -p <password>
+aws iam create-login-profile --user-name "$USERNAME" --password "$PASSWORD"
+unset $PASSWORD
+
+# re-enable echoing
+set -x
 
 # Command to Verify that your user was created:
 aws iam list-users

--- a/bin/set_up_govcloud.sh
+++ b/bin/set_up_govcloud.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# required environment variables:
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+# USERNAME (optional - set on system by default)
+
+# based on
+# https://govcloudconsolesetup.s3-us-gov-west-1.amazonaws.com/setup.html
+
+export AWS_DEFAULT_REGION=us-gov-west-1
+GROUP_NAME=Administrators
+
+aws iam create-group --group-name "$GROUP_NAME"
+
+# Command to Add a Policy to the group:
+aws iam attach-group-policy --group-name "$GROUP_NAME" --policy-arn arn:aws:iam::aws:policy/AdministratorAccess
+
+# Command to create a new user and add them to the group:
+aws iam create-user --user-name "$USERNAME"
+aws iam add-user-to-group --group-name "$GROUP_NAME" --user-name "$USERNAME"
+
+# Command to add a password to the user:
+aws iam create-login-profile -u "$USERNAME" -p <password>
+
+# Command to Verify that your user was created:
+aws iam list-users

--- a/bin/set_up_govcloud.sh
+++ b/bin/set_up_govcloud.sh
@@ -27,7 +27,7 @@ aws iam add-user-to-group --group-name "$GROUP_NAME" --user-name "$USERNAME"
 set +x
 
 # Read Password
-echo -n "Password for new IAM user: "
+echo -n "Password for new IAM user ($USERNAME): "
 read -s PASSWORD
 echo
 
@@ -40,3 +40,6 @@ set -x
 
 # Command to Verify that your user was created:
 aws iam list-users
+
+GOVCLOUD_ACCOUNT_NUMBER=$(aws sts get-caller-identity --query Account --output text)
+echo "Sign in as $USERNAME at https://$GOVCLOUD_ACCOUNT_NUMBER.signin.amazonaws-us-gov.com/console"


### PR DESCRIPTION
Supports https://github.com/18F/aws-admin/issues/49.

[The provided instructions](https://govcloudconsolesetup.s3-us-gov-west-1.amazonaws.com/setup.html) are tedious and broken. (I have said both to AWS.) This automates it a bit.