### PR TITLE
add a read-only group for billing

### DIFF
--- a/terraform/payer.tf
+++ b/terraform/payer.tf
@@ -1,0 +1,13 @@
+# for viewing billing across the AWS Organization
+resource "aws_iam_group" "org_wide_billing" {
+  provider = aws.payer
+
+  name = "TenantBilling"
+}
+
+resource "aws_iam_group_policy_attachment" "org_wide_billing" {
+  provider = aws.payer
+
+  group      = aws_iam_group.org_wide_billing.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
+}

--- a/terraform/payer.tf
+++ b/terraform/payer.tf
@@ -1,11 +1,11 @@
 # for viewing billing across the AWS Organization
-resource "aws_iam_group" "org_wide_billing" {
+resource "aws_iam_group" "tenant_biller" {
   provider = aws.payer
 
-  name = "TenantBilling"
+  name = "TenantBiller"
 }
 
-resource "aws_iam_group_policy_attachment" "org_wide_billing" {
+resource "aws_iam_group_policy_attachment" "tenant_biller" {
   provider = aws.payer
 
   group      = aws_iam_group.org_wide_billing.name


### PR DESCRIPTION
We have gotten requests from users with multiple AWS accounts to be able to see billing across them. There's definitely a better way to do this, but hoping this is "good enough" for right now.