### PR TITLE
WIP - Add draft per-account daily_budget alert

### DIFF
--- a/terraform/account/daily_budget.tf
+++ b/terraform/account/daily_budget.tf
@@ -1,0 +1,32 @@
+resource "aws_budgets_budget" "daily_budget" {
+  count = var.daily_budget_usd > 0 ? 1 : 0
+
+  name = var.name
+
+  budget_type = "COST"
+  limit_unit  = "USD"
+  # for some reason it adds a single decimal
+  limit_amount      = "${var.daily_budget_usd}.0"
+  time_period_start = "2019-11-07_00:00"
+  time_unit         = "DAILY"
+
+  cost_filters = {
+    LinkedAccount = var.account_id
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.daily_budget_emails
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.daily_budget_emails
+  }
+}

--- a/terraform/account/vars.tf
+++ b/terraform/account/vars.tf
@@ -5,3 +5,15 @@ variable "name" {
 variable "org_unit_id" {
   type = string
 }
+
+variable "daily_budget_usd" {
+  description = "Daily account spending limit in whole US dollars - Leave at 0 for no limit"
+  type        = number
+  default     = 0
+}
+
+variable "daily_budget_emails" {
+  description = "List of email addresses to notify if daily budget exceeded"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/login_gov.tf
+++ b/terraform/login_gov.tf
@@ -9,19 +9,22 @@ module "login_gov" {
 }
 
 module "login_gov_alpha" {
-  source      = "./account"
-  providers   = {
-                  aws = aws.payer
+  source = "./account"
+  providers = {
+    aws = aws.payer
   }
 
-  name        = "login-alpha"
-  org_unit_id = module.login_gov.org_unit_id
+  name             = "login-alpha"
+  org_unit_id      = module.login_gov.org_unit_id
+  daily_budget_usd = 100
+  # Not secret, but maybe better in SSM parameter store?
+  daily_budget_emails = ["opsgenie@whatever.wha", "slack@whateverelse.net"]
 }
 
 module "login_gov_identity_give_test" {
-  source      = "./account"
-  providers   = {
-                  aws = aws.payer
+  source = "./account"
+  providers = {
+    aws = aws.payer
   }
 
   name        = "identity-give-test"
@@ -29,9 +32,9 @@ module "login_gov_identity_give_test" {
 }
 
 module "login_gov_identity_give_dev" {
-  source      = "./account"
-  providers   = {
-                  aws = aws.payer
+  source = "./account"
+  providers = {
+    aws = aws.payer
   }
 
   name        = "identity-give-dev"


### PR DESCRIPTION
# The Story

As a **TTS Solutions engineer** I would like to **set daily budget limits with email alerts** so I may **add finer grained spending limits for fast feedback while still retaining the program (BU) budgets already in place.**

# Solution

This adds an optional per-account "daily_budget" resource when the `daily_budget_usd` variable is set in an account resource block.   The `daily_budget_emails` list will be notified if the forecast or absolute budget is exceeded for a given day.

Open question: This shows setting email addresses in TF but I leave it to the team as to where these should live. 

Sample plan:

~~~
  # module.main.aws_budgets_budget.daily_budget[0] will be created
  + resource "aws_budgets_budget" "daily_budget" {
      + account_id        = (known after apply)
      + budget_type       = "COST"
      + cost_filters      = {
          + "LinkedAccount" = "1234567890"
        }
      + id                = (known after apply)
      + limit_amount      = "100.0"
      + limit_unit        = "USD"
      + name              = "bob"
      + name_prefix       = (known after apply)
      + time_period_end   = "2087-06-15_00:00"
      + time_period_start = "2019-11-07_00:00"
      + time_unit         = "DAILY"

      + cost_types {
          + include_credit             = (known after apply)
          + include_discount           = (known after apply)
          + include_other_subscription = (known after apply)
          + include_recurring          = (known after apply)
          + include_refund             = (known after apply)
          + include_subscription       = (known after apply)
          + include_support            = (known after apply)
          + include_tax                = (known after apply)
          + include_upfront            = (known after apply)
          + use_amortized              = (known after apply)
          + use_blended                = (known after apply)
        }

      + notification {
          + comparison_operator        = "GREATER_THAN"
          + notification_type          = "ACTUAL"
          + subscriber_email_addresses = [
              + "opsgenie@whatever.wha",
              + "slack@whateverelse.net",
            ]
          + subscriber_sns_topic_arns  = []
          + threshold                  = 100
          + threshold_type             = "PERCENTAGE"
        }
      + notification {
          + comparison_operator        = "GREATER_THAN"
          + notification_type          = "FORECASTED"
          + subscriber_email_addresses = [
              + "opsgenie@whatever.wha",
              + "slack@whateverelse.net",
            ]
          + subscriber_sns_topic_arns  = []
          + threshold                  = 100
          + threshold_type             = "PERCENTAGE"
        }
    }
~~~
